### PR TITLE
Add multi-page router and summary

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,26 @@
-import React from 'react';
-import { BrowserRouter as Router } from 'react-router-dom';
+import React, { useState } from 'react';
+import { BrowserRouter as Router, Routes, Route, Link, Navigate } from 'react-router-dom';
 import OrganizationTree from './generator';
+import Summary from './Summary';
 
 const App = () => {
+  const [totals, setTotals] = useState({ chart1: 0, chart2: 0, chart3: 0 });
+
   return (
     <Router basename={process.env.PUBLIC_URL}>
-      <OrganizationTree />
+      <nav className="p-4 space-x-4 border-b mb-4">
+        <Link to="/chart1">조직도 1</Link>
+        <Link to="/chart2">조직도 2</Link>
+        <Link to="/chart3">조직도 3</Link>
+        <Link to="/summary">합계</Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<Navigate to="/chart1" replace />} />
+        <Route path="/chart1" element={<OrganizationTree onTotalChange={(t) => setTotals(prev => ({ ...prev, chart1: t }))} />} />
+        <Route path="/chart2" element={<OrganizationTree onTotalChange={(t) => setTotals(prev => ({ ...prev, chart2: t }))} />} />
+        <Route path="/chart3" element={<OrganizationTree onTotalChange={(t) => setTotals(prev => ({ ...prev, chart3: t }))} />} />
+        <Route path="/summary" element={<Summary totals={totals} />} />
+      </Routes>
     </Router>
   );
 };

--- a/src/Summary.js
+++ b/src/Summary.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const Summary = ({ totals }) => {
+  const totalSum = Object.values(totals).reduce((acc, v) => acc + v, 0);
+  return (
+    <div className="p-8">
+      <h1 className="text-xl font-bold mb-4">총 인원 합계</h1>
+      <ul className="mb-4 space-y-2">
+        <li>조직도 1: {totals.chart1}</li>
+        <li>조직도 2: {totals.chart2}</li>
+        <li>조직도 3: {totals.chart3}</li>
+      </ul>
+      <div className="text-lg font-bold">합계: {totalSum}</div>
+    </div>
+  );
+};
+
+export default Summary;

--- a/src/generator.js
+++ b/src/generator.js
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
-const OrganizationTree = () => {
+const OrganizationTree = ({ onTotalChange }) => {
   const [config, setConfig] = useState({
     lineCount: 4,
     shiftsCount: 2,
@@ -117,6 +117,20 @@ const OrganizationTree = () => {
       ]
     }
   ];
+
+  const computeTotalPositions = () => {
+    const processGroups = getProcessGroups();
+    const perLine = 1 + processGroups.reduce((sum, group) => {
+      return sum + 1 + group.tlGroup.length + (group.tmGroup ? group.tmGroup.length : 0);
+    }, 0);
+    return 1 + config.lineCount * perLine;
+  };
+
+  useEffect(() => {
+    if (onTotalChange) {
+      onTotalChange(computeTotalPositions());
+    }
+  }, [config]);
 
   const VSMGroup = ({ vsm }) => {
     const processGroups = getProcessGroups();


### PR DESCRIPTION
## Summary
- update `App` to route between three org chart pages and a summary page
- compute total positions in `OrganizationTree` and expose via `onTotalChange`
- add new `Summary` page to display totals

## Testing
- `npm run build` *(fails: react-scripts not found)*
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*