### PR TITLE
Show rank totals in summary page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,31 @@
-import React from 'react';
-import { BrowserRouter as Router } from 'react-router-dom';
+import React, { useState } from 'react';
+import { BrowserRouter as Router, Routes, Route, Link, Navigate } from 'react-router-dom';
 import OrganizationTree from './generator';
+import Summary from './Summary';
 
 const App = () => {
+  const empty = { mgl: 0, vsm: 0, gl: 0, tl: 0, tm: 0, total: 0 };
+  const [totals, setTotals] = useState({
+    chart1: { ...empty },
+    chart2: { ...empty },
+    chart3: { ...empty }
+  });
+
   return (
     <Router basename={process.env.PUBLIC_URL}>
-      <OrganizationTree />
+      <nav className="p-4 space-x-4 border-b mb-4">
+        <Link to="/chart1">조직도 1</Link>
+        <Link to="/chart2">조직도 2</Link>
+        <Link to="/chart3">조직도 3</Link>
+        <Link to="/summary">합계</Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<Navigate to="/chart1" replace />} />
+        <Route path="/chart1" element={<OrganizationTree onTotalChange={(t) => setTotals(prev => ({ ...prev, chart1: t }))} />} />
+        <Route path="/chart2" element={<OrganizationTree onTotalChange={(t) => setTotals(prev => ({ ...prev, chart2: t }))} />} />
+        <Route path="/chart3" element={<OrganizationTree onTotalChange={(t) => setTotals(prev => ({ ...prev, chart3: t }))} />} />
+        <Route path="/summary" element={<Summary totals={totals} />} />
+      </Routes>
     </Router>
   );
 };

--- a/src/Summary.js
+++ b/src/Summary.js
@@ -1,0 +1,41 @@
+import React from 'react';
+
+const Summary = ({ totals }) => {
+  const charts = Object.values(totals);
+  const totalSum = charts.reduce((acc, v) => acc + (v.total || 0), 0);
+
+  const rankTotals = charts.reduce(
+    (acc, t) => {
+      acc.mgl += t.mgl || 0;
+      acc.vsm += t.vsm || 0;
+      acc.gl += t.gl || 0;
+      acc.tl += t.tl || 0;
+      acc.tm += t.tm || 0;
+      return acc;
+    },
+    { mgl: 0, vsm: 0, gl: 0, tl: 0, tm: 0 }
+  );
+
+  return (
+    <div className="p-8">
+      <h1 className="text-xl font-bold mb-4">총 인원 합계</h1>
+      <ul className="mb-4 space-y-2">
+        <li>조직도 1: {totals.chart1.total}</li>
+        <li>조직도 2: {totals.chart2.total}</li>
+        <li>조직도 3: {totals.chart3.total}</li>
+      </ul>
+      <div className="text-lg font-bold mb-6">합계: {totalSum}</div>
+
+      <h2 className="text-xl font-bold mb-2">직급별 합계</h2>
+      <ul className="space-y-1">
+        <li>MGL: {rankTotals.mgl}</li>
+        <li>VSM: {rankTotals.vsm}</li>
+        <li>GL: {rankTotals.gl}</li>
+        <li>TL: {rankTotals.tl}</li>
+        <li>TM: {rankTotals.tm}</li>
+      </ul>
+    </div>
+  );
+};
+
+export default Summary;

--- a/src/generator.js
+++ b/src/generator.js
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
-const OrganizationTree = () => {
+const OrganizationTree = ({ onTotalChange }) => {
   const [config, setConfig] = useState({
     lineCount: 4,
     shiftsCount: 2,
@@ -117,6 +117,34 @@ const OrganizationTree = () => {
       ]
     }
   ];
+
+  const computePositionTotals = () => {
+    const processGroups = getProcessGroups();
+    const glPerLine = processGroups.length;
+    const tlPerLine = processGroups.reduce((sum, g) => sum + g.tlGroup.length, 0);
+    const tmPerLine = processGroups.reduce(
+      (sum, g) => sum + (g.tmGroup ? g.tmGroup.length : 0),
+      0
+    );
+
+    const totals = {
+      mgl: 1,
+      vsm: config.lineCount,
+      gl: config.lineCount * glPerLine,
+      tl: config.lineCount * tlPerLine,
+      tm: config.lineCount * tmPerLine
+    };
+    totals.total =
+      totals.mgl + totals.vsm + totals.gl + totals.tl + totals.tm;
+
+    return totals;
+  };
+
+  useEffect(() => {
+    if (onTotalChange) {
+      onTotalChange(computePositionTotals());
+    }
+  }, [config]);
 
   const VSMGroup = ({ vsm }) => {
     const processGroups = getProcessGroups();


### PR DESCRIPTION
## Summary
- update organization totals to provide per-rank numbers
- display each rank's combined total on the summary page

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*